### PR TITLE
accounts-service: Add support for oars-1.1

### DIFF
--- a/accounts-service/com.endlessm.ParentalControls.AppFilter.xml
+++ b/accounts-service/com.endlessm.ParentalControls.AppFilter.xml
@@ -41,7 +41,7 @@
 
       It’s a two-tuple of the rating type, and a dictionary of rating sections
       and values. The type gives the rating scheme in use — currently only
-      `oars-1.0` is supported.
+      `oars-1.0` and `oars-1.1` are supported.
 
       Each dictionary entry is a mapping from an OARS section to the
       most severe value for it which the user is allowed to see (inclusive). Any
@@ -57,7 +57,7 @@
     -->
     <property name="oars-filter" type="(sa{ss})" access="readwrite">
       <annotation name="org.freedesktop.Accounts.DefaultValue"
-        value="('oars-1.0', @a{ss} {})"/>
+        value="('oars-1.1', @a{ss} {})"/>
     </property>
   </interface>
 </node>

--- a/libeos-parental-controls/app-filter.c
+++ b/libeos-parental-controls/app-filter.c
@@ -403,13 +403,14 @@ get_app_filter_cb (GObject      *obj,
                          &content_rating_kind, &oars_variant))
     {
       /* Default value. */
-      content_rating_kind = "oars-1.0";
+      content_rating_kind = "oars-1.1";
       oars_variant = g_variant_new ("@a{ss} {}");
     }
 
   /* Check that the OARS filter is in a format we support. Currently, that’s
-   * only oars-1.0. */
-  if (!g_str_equal (content_rating_kind, "oars-1.0"))
+   * only oars-1.0 and oars-1.1. */
+  if (!g_str_equal (content_rating_kind, "oars-1.0") &&
+      !g_str_equal (content_rating_kind, "oars-1.1"))
     {
       g_task_return_new_error (task, EPC_APP_FILTER_ERROR,
                                EPC_APP_FILTER_ERROR_INVALID_DATA,


### PR DESCRIPTION
Even though I can’t find a single copy of the specification or how it
differs from oars-1.0; it allegedly exists.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T23999