### PR TITLE
T24020 flatpak support

### DIFF
--- a/libeos-parental-controls/app-filter.h
+++ b/libeos-parental-controls/app-filter.h
@@ -97,9 +97,11 @@ void          epc_app_filter_unref (EpcAppFilter *filter);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (EpcAppFilter, epc_app_filter_unref)
 
-uid_t    epc_app_filter_get_user_id     (EpcAppFilter *filter);
-gboolean epc_app_filter_is_path_allowed (EpcAppFilter *filter,
-                                         const gchar  *path);
+uid_t    epc_app_filter_get_user_id            (EpcAppFilter *filter);
+gboolean epc_app_filter_is_path_allowed        (EpcAppFilter *filter,
+                                                const gchar  *path);
+gboolean epc_app_filter_is_flatpak_ref_allowed (EpcAppFilter *filter,
+                                                const gchar  *flatpak_ref);
 
 EpcAppFilterOarsValue epc_app_filter_get_oars_value (EpcAppFilter *filter,
                                                      const gchar  *oars_section);
@@ -177,10 +179,12 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (EpcAppFilterBuilder, epc_app_filter_builder_free)
 
 EpcAppFilter *epc_app_filter_builder_end (EpcAppFilterBuilder *builder);
 
-void epc_app_filter_builder_blacklist_path (EpcAppFilterBuilder   *builder,
-                                            const gchar           *path);
-void epc_app_filter_builder_set_oars_value (EpcAppFilterBuilder   *builder,
-                                            const gchar           *oars_section,
-                                            EpcAppFilterOarsValue  value);
+void epc_app_filter_builder_blacklist_path        (EpcAppFilterBuilder   *builder,
+                                                   const gchar           *path);
+void epc_app_filter_builder_blacklist_flatpak_ref (EpcAppFilterBuilder *builder,
+                                                   const gchar         *app_ref);
+void epc_app_filter_builder_set_oars_value        (EpcAppFilterBuilder   *builder,
+                                                   const gchar           *oars_section,
+                                                   EpcAppFilterOarsValue  value);
 
 G_END_DECLS

--- a/libeos-parental-controls/tests/app-filter.c
+++ b/libeos-parental-controls/tests/app-filter.c
@@ -102,6 +102,9 @@ test_app_filter_builder_non_empty (BuilderFixture *fixture,
   epc_app_filter_builder_blacklist_path (fixture->builder, "/bin/true");
   epc_app_filter_builder_blacklist_path (fixture->builder, "/usr/bin/gnome-software");
 
+  epc_app_filter_builder_blacklist_flatpak_ref (fixture->builder,
+                                                "app/org.doom.Doom/x86_64/master");
+
   epc_app_filter_builder_set_oars_value (fixture->builder, "drugs-alcohol",
                                          EPC_APP_FILTER_OARS_VALUE_MILD);
   epc_app_filter_builder_set_oars_value (fixture->builder, "language-humor",
@@ -112,6 +115,11 @@ test_app_filter_builder_non_empty (BuilderFixture *fixture,
   g_assert_true (epc_app_filter_is_path_allowed (filter, "/bin/false"));
   g_assert_false (epc_app_filter_is_path_allowed (filter,
                                                   "/usr/bin/gnome-software"));
+
+  g_assert_true (epc_app_filter_is_flatpak_ref_allowed (filter,
+                                                        "app/org.gnome.Ponies/x86_64/master"));
+  g_assert_false (epc_app_filter_is_flatpak_ref_allowed (filter,
+                                                         "app/org.doom.Doom/x86_64/master"));
 
   g_assert_cmpint (epc_app_filter_get_oars_value (filter, "drugs-alcohol"), ==,
                    EPC_APP_FILTER_OARS_VALUE_MILD);
@@ -133,6 +141,11 @@ test_app_filter_builder_empty (BuilderFixture *fixture,
   g_assert_true (epc_app_filter_is_path_allowed (filter, "/bin/false"));
   g_assert_true (epc_app_filter_is_path_allowed (filter,
                                                  "/usr/bin/gnome-software"));
+
+  g_assert_true (epc_app_filter_is_flatpak_ref_allowed (filter,
+                                                        "app/org.gnome.Ponies/x86_64/master"));
+  g_assert_true (epc_app_filter_is_flatpak_ref_allowed (filter,
+                                                        "app/org.doom.Doom/x86_64/master"));
 
   g_assert_cmpint (epc_app_filter_get_oars_value (filter, "drugs-alcohol"), ==,
                    EPC_APP_FILTER_OARS_VALUE_UNKNOWN);


### PR DESCRIPTION
Add support for flatpak refs to the API. This is needed for T24020.

https://phabricator.endlessm.com/T24020

This PR is based on top of #5 and #6, so can only be merged once they are.