### PR TITLE
T24024 libeos-parental-controls: Add synchronous versions of methods

### DIFF
--- a/eos-parental-controls-client/eos-parental-controls-client.py
+++ b/eos-parental-controls-client/eos-parental-controls-client.py
@@ -37,28 +37,9 @@ def __get_app_filter(user_id, interactive):
 
     If `interactive` is `True`, interactive polkit authorisation dialogues will
     be allowed. An exception will be raised on failure."""
-    app_filter = None
-    exception = None
-
-    def __get_cb(obj, result, user_data):
-        nonlocal app_filter, exception
-        try:
-            app_filter = EosParentalControls.get_app_filter_finish(result)
-        except Exception as e:
-            exception = e
-
-    EosParentalControls.get_app_filter_async(
+    return EosParentalControls.get_app_filter(
         connection=None, user_id=user_id,
-        allow_interactive_authorization=interactive, cancellable=None,
-        callback=__get_cb, user_data=None)
-
-    context = GLib.MainContext.default()
-    while not app_filter and not exception:
-        context.iteration(True)
-
-    if exception:
-        raise exception
-    return app_filter
+        allow_interactive_authorization=interactive, cancellable=None)
 
 
 def __get_app_filter_or_error(user_id, interactive):
@@ -77,28 +58,9 @@ def __set_app_filter(user_id, app_filter, interactive):
 
     If `interactive` is `True`, interactive polkit authorisation dialogues will
     be allowed. An exception will be raised on failure."""
-    finished = False
-    exception = None
-
-    def __set_cb(obj, result, user_data):
-        nonlocal finished, exception
-        try:
-            EosParentalControls.set_app_filter_finish(result)
-            finished = True
-        except Exception as e:
-            exception = e
-
-    EosParentalControls.set_app_filter_async(
+    EosParentalControls.set_app_filter(
         connection=None, user_id=user_id, app_filter=app_filter,
-        allow_interactive_authorization=interactive, cancellable=None,
-        callback=__set_cb, user_data=None)
-
-    context = GLib.MainContext.default()
-    while not finished and not exception:
-        context.iteration(True)
-
-    if exception:
-        raise exception
+        allow_interactive_authorization=interactive, cancellable=None)
 
 
 def __set_app_filter_or_error(user_id, app_filter, interactive):

--- a/libeos-parental-controls/app-filter.c
+++ b/libeos-parental-controls/app-filter.c
@@ -332,8 +332,8 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (GetAppFilterData, get_app_filter_data_free)
  * @user_id: ID of the user to query, typically coming from getuid()
  * @allow_interactive_authorization: %TRUE to allow interactive polkit
  *    authorization dialogues to be displayed during the call; %FALSE otherwise
- * @callback: a #GAsyncReadyCallback
  * @cancellable: (nullable): a #GCancellable, or %NULL
+ * @callback: a #GAsyncReadyCallback
  * @user_data: user data to pass to @callback
  *
  * Asynchronously get a snapshot of the app filter settings for the given
@@ -561,8 +561,8 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (SetAppFilterData, set_app_filter_data_free)
  * @app_filter: (transfer none): the app filter to set for the user
  * @allow_interactive_authorization: %TRUE to allow interactive polkit
  *    authorization dialogues to be displayed during the call; %FALSE otherwise
- * @callback: a #GAsyncReadyCallback
  * @cancellable: (nullable): a #GCancellable, or %NULL
+ * @callback: a #GAsyncReadyCallback
  * @user_data: user data to pass to @callback
  *
  * Asynchronously set the app filter settings for the given @user_id to the

--- a/libeos-parental-controls/app-filter.h
+++ b/libeos-parental-controls/app-filter.h
@@ -106,6 +106,11 @@ gboolean epc_app_filter_is_flatpak_ref_allowed (EpcAppFilter *filter,
 EpcAppFilterOarsValue epc_app_filter_get_oars_value (EpcAppFilter *filter,
                                                      const gchar  *oars_section);
 
+EpcAppFilter *epc_get_app_filter        (GDBusConnection      *connection,
+                                         uid_t                 user_id,
+                                         gboolean              allow_interactive_authorization,
+                                         GCancellable         *cancellable,
+                                         GError              **error);
 void          epc_get_app_filter_async  (GDBusConnection      *connection,
                                          uid_t                 user_id,
                                          gboolean              allow_interactive_authorization,
@@ -115,6 +120,12 @@ void          epc_get_app_filter_async  (GDBusConnection      *connection,
 EpcAppFilter *epc_get_app_filter_finish (GAsyncResult         *result,
                                          GError              **error);
 
+gboolean      epc_set_app_filter        (GDBusConnection      *connection,
+                                         uid_t                 user_id,
+                                         EpcAppFilter         *app_filter,
+                                         gboolean              allow_interactive_authorization,
+                                         GCancellable         *cancellable,
+                                         GError              **error);
 void          epc_set_app_filter_async  (GDBusConnection      *connection,
                                          uid_t                 user_id,
                                          EpcAppFilter         *app_filter,


### PR DESCRIPTION
Refactor the asynchronous implementation to run the synchronous
implementation in a thread. The synchronous version seems to be what’s
needed for most callers.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24024