### PR TITLE
libeos-parental-controls: Add epc_app_filter_is_oars_set() API

### DIFF
--- a/libeos-parental-controls/app-filter.c
+++ b/libeos-parental-controls/app-filter.c
@@ -197,6 +197,35 @@ epc_app_filter_is_flatpak_ref_allowed (EpcAppFilter *filter,
 }
 
 /**
+ * epc_app_filter_is_oars_set:
+ * @filter: an #EpcAppFilter
+ *
+ * Get whether any OARS sections are set to a known value in the filter. If the
+ * filter has no OARS sections set, or all sections are set to
+ * %EPC_APP_FILTER_OARS_VALUE_UNKNOWN, %FALSE will be returned. Otherwise %TRUE
+ * will be returned.
+ *
+ * Returns: %TRUE if any OARS sections are set, %FALSE otherwise
+ * Since: 0.1.0
+ */
+gboolean
+epc_app_filter_is_oars_set (EpcAppFilter *filter)
+{
+  GVariantIter iter;
+  const gchar *value_str;
+
+  g_variant_iter_init (&iter, filter->oars_ratings);
+
+  while (g_variant_iter_loop (&iter, "{&s&s}", NULL, &value_str))
+    {
+      if (!g_str_equal (value_str, "unknown"))
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
+/**
  * epc_app_filter_get_oars_value:
  * @filter: an #EpcAppFilter
  * @oars_section: name of the OARS section to get the value from

--- a/libeos-parental-controls/app-filter.h
+++ b/libeos-parental-controls/app-filter.h
@@ -103,6 +103,7 @@ gboolean epc_app_filter_is_path_allowed        (EpcAppFilter *filter,
 gboolean epc_app_filter_is_flatpak_ref_allowed (EpcAppFilter *filter,
                                                 const gchar  *flatpak_ref);
 
+gboolean              epc_app_filter_is_oars_set    (EpcAppFilter *filter);
 EpcAppFilterOarsValue epc_app_filter_get_oars_value (EpcAppFilter *filter,
                                                      const gchar  *oars_section);
 

--- a/libeos-parental-controls/tests/app-filter.c
+++ b/libeos-parental-controls/tests/app-filter.c
@@ -127,6 +127,7 @@ test_app_filter_builder_non_empty (BuilderFixture *fixture,
                    EPC_APP_FILTER_OARS_VALUE_MODERATE);
   g_assert_cmpint (epc_app_filter_get_oars_value (filter, "something-else"), ==,
                    EPC_APP_FILTER_OARS_VALUE_UNKNOWN);
+  g_assert_true (epc_app_filter_is_oars_set (filter));
 }
 
 /* Test building an empty #EpcAppFilter using an #EpcAppFilterBuilder. */
@@ -153,6 +154,7 @@ test_app_filter_builder_empty (BuilderFixture *fixture,
                    EPC_APP_FILTER_OARS_VALUE_UNKNOWN);
   g_assert_cmpint (epc_app_filter_get_oars_value (filter, "something-else"), ==,
                    EPC_APP_FILTER_OARS_VALUE_UNKNOWN);
+  g_assert_false (epc_app_filter_is_oars_set (filter));
 }
 
 /* Check that copying a cleared #EpcAppFilterBuilder works, and the copy can


### PR DESCRIPTION
This is a convenience getter to test whether any OARS sections are set
to non-unknown values in the filter. It will be used by clients to
determine whether they need to care about OARS.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24024