### PR TITLE
libeos-parental-controls: Support matching against flatpak app IDs

### DIFF
--- a/eos-parental-controls-client/eos-parental-controls-client.py
+++ b/eos-parental-controls-client/eos-parental-controls-client.py
@@ -150,7 +150,12 @@ def command_check(user, path, quiet=False, interactive=True):
     user_id = __lookup_user_id_or_error(user)
     app_filter = __get_app_filter_or_error(user_id, interactive)
 
-    if path.startswith('app/') or path.startswith('runtime/'):
+    if path.startswith('app/') and path.count('/') < 3:
+        # Flatpak app ID
+        path = path[4:]
+        is_allowed = app_filter.is_flatpak_app_allowed(path)
+        noun = 'Flatpak app ID'
+    elif path.startswith('app/') or path.startswith('runtime/'):
         # Flatpak ref
         is_allowed = app_filter.is_flatpak_ref_allowed(path)
         noun = 'Flatpak ref'

--- a/libeos-parental-controls/app-filter.h
+++ b/libeos-parental-controls/app-filter.h
@@ -102,6 +102,8 @@ gboolean epc_app_filter_is_path_allowed        (EpcAppFilter *filter,
                                                 const gchar  *path);
 gboolean epc_app_filter_is_flatpak_ref_allowed (EpcAppFilter *filter,
                                                 const gchar  *app_ref);
+gboolean epc_app_filter_is_flatpak_app_allowed (EpcAppFilter *filter,
+                                                const gchar  *app_id);
 
 const gchar           **epc_app_filter_get_oars_sections (EpcAppFilter *filter);
 EpcAppFilterOarsValue   epc_app_filter_get_oars_value    (EpcAppFilter *filter,

--- a/libeos-parental-controls/tests/app-filter.c
+++ b/libeos-parental-controls/tests/app-filter.c
@@ -135,8 +135,10 @@ test_app_filter_builder_non_empty (BuilderFixture *fixture,
 
   g_assert_true (epc_app_filter_is_flatpak_ref_allowed (filter,
                                                         "app/org.gnome.Ponies/x86_64/master"));
+  g_assert_true (epc_app_filter_is_flatpak_app_allowed (filter, "org.gnome.Ponies"));
   g_assert_false (epc_app_filter_is_flatpak_ref_allowed (filter,
                                                          "app/org.doom.Doom/x86_64/master"));
+  g_assert_false (epc_app_filter_is_flatpak_app_allowed (filter, "org.doom.Doom"));
 
   g_assert_cmpint (epc_app_filter_get_oars_value (filter, "drugs-alcohol"), ==,
                    EPC_APP_FILTER_OARS_VALUE_MILD);
@@ -168,8 +170,10 @@ test_app_filter_builder_empty (BuilderFixture *fixture,
 
   g_assert_true (epc_app_filter_is_flatpak_ref_allowed (filter,
                                                         "app/org.gnome.Ponies/x86_64/master"));
+  g_assert_true (epc_app_filter_is_flatpak_app_allowed (filter, "org.gnome.Ponies"));
   g_assert_true (epc_app_filter_is_flatpak_ref_allowed (filter,
                                                         "app/org.doom.Doom/x86_64/master"));
+  g_assert_true (epc_app_filter_is_flatpak_app_allowed (filter, "org.doom.Doom"));
 
   g_assert_cmpint (epc_app_filter_get_oars_value (filter, "drugs-alcohol"), ==,
                    EPC_APP_FILTER_OARS_VALUE_UNKNOWN);


### PR DESCRIPTION
These are the app-specific part of a flatpak ref, and are what’s
available when you have a .desktop file, via the X-Flatpak key in the
.desktop file. For example, for a flatpak ref
‘app/org.gnome.Builder/x86_64/master’, the app ID is
‘org.gnome.Builder’. It makes sense that we’d want to match against app
IDs in some situations, since the user probably doesn’t care about the
architecture or branch of the app they want to proscribe.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24016