### PR TITLE
libeos-parental-controls: Strip the correct string

### DIFF
--- a/libeos-parental-controls/app-filter.c
+++ b/libeos-parental-controls/app-filter.c
@@ -303,7 +303,7 @@ epc_app_filter_is_appinfo_allowed (EpcAppFilter *filter,
 
           for (gsize i = 0; old_flatpak_apps[i] != NULL; i++)
             {
-              gchar *old_flatpak_app = g_strstrip (old_flatpak_app);
+              gchar *old_flatpak_app = g_strstrip (old_flatpak_apps[i]);
 
               if (g_str_has_suffix (old_flatpak_app, ".desktop"))
                 old_flatpak_app[strlen (old_flatpak_app) - strlen (".desktop")] = '\0';


### PR DESCRIPTION
At epc_app_filter_is_appinfo_allowed(), we can read:

  gchar *old_flatpak_app = g_strstrip (old_flatpak_app);

Which is, naturally, wrong. We can't string an unassigned
string.

Fix that by stripping the string that was supposed to be
stripped there, that is, "old_flatpak_apps[i]".