### PR TITLE
lib: Cast integers of type uid_t to appropriate types for varargs

### DIFF
--- a/libeos-parental-controls/app-filter.c
+++ b/libeos-parental-controls/app-filter.c
@@ -508,11 +508,11 @@ bus_error_to_app_filter_error (const GError *bus_error,
       bus_remote_error_matches (bus_error, "org.freedesktop.Accounts.Error.PermissionDenied"))
     return g_error_new (EPC_APP_FILTER_ERROR, EPC_APP_FILTER_ERROR_PERMISSION_DENIED,
                         _("Not allowed to query app filter data for user %u"),
-                        user_id);
+                        (guint) user_id);
   else if (g_error_matches (bus_error, G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_METHOD) ||
            bus_remote_error_matches (bus_error, "org.freedesktop.Accounts.Error.Failed"))
     return g_error_new (EPC_APP_FILTER_ERROR, EPC_APP_FILTER_ERROR_INVALID_USER,
-                        _("User %u does not exist"), user_id);
+                        _("User %u does not exist"), (guint) user_id);
   else
     return g_error_copy (bus_error);
 }
@@ -537,7 +537,7 @@ accounts_find_user_by_id (GDBusConnection  *connection,
                                    "/org/freedesktop/Accounts",
                                    "org.freedesktop.Accounts",
                                    "FindUserById",
-                                   g_variant_new ("(x)", user_id),
+                                   g_variant_new ("(x)", (gint64) user_id),
                                    G_VARIANT_TYPE ("(o)"),
                                    allow_interactive_authorization
                                      ? G_DBUS_CALL_FLAGS_ALLOW_INTERACTIVE_AUTHORIZATION
@@ -639,7 +639,7 @@ epc_get_app_filter (GDBusConnection  *connection,
       g_set_error (error, EPC_APP_FILTER_ERROR,
                    EPC_APP_FILTER_ERROR_PERMISSION_DENIED,
                    _("Not allowed to query app filter data for user %u"),
-                   user_id);
+                   (guint) user_id);
       return NULL;
     }
 
@@ -659,7 +659,7 @@ epc_get_app_filter (GDBusConnection  *connection,
       g_set_error (error, EPC_APP_FILTER_ERROR,
                    EPC_APP_FILTER_ERROR_INVALID_DATA,
                    _("OARS filter for user %u has an unrecognized kind ‘%s’"),
-                   user_id, content_rating_kind);
+                   (guint) user_id, content_rating_kind);
       return NULL;
     }
 


### PR DESCRIPTION
When querying for the details of a particular user by their UID, we call
accountsservice over D-Bus. Its API takes a gint64 variant, which we
build using g_variant_new(), which takes varargs. Passing an integer of
type uid_t in the varargs works fine on 64-bit architectures, where
uid_t is 64-bit, but not on other architectures, where it’s likely
32-bit. In that case, g_variant_new() will still read 64 bits from the
varargs input, even though the caller only put 32 on there. The rest
will be filled with rubbish.

Fix that by explicitly casting the uid_t to gint64 in the varargs. Fix a
few other areas where uid_t variables are passed to functions which
might interpret them as a different kind of integer too.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24016