### PR TITLE
build: Force libglib-testing to link statically

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,10 @@ polkitpolicydir = polkit_gobject.get_pkgconfig_variable('policydir',
   define_variable: ['prefix', prefix])
 
 libglib_testing = subproject('libglib-testing')
-libglib_testing_dep = libglib_testing.get_variable('libglib_testing_dep')
+libglib_testing_dep = dependency(
+  'libglib-testing',
+  fallback: ['libglib-testing', 'libglib_testing_dep'],
+)
 
 config_h = configuration_data()
 config_h.set_quoted('GETTEXT_PACKAGE', meson.project_name())


### PR DESCRIPTION
If the tests are linked to it dynamically, they won’t run without it
installed system wide, which is not what we want.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24004