### PR TITLE
accounts-service: Add polkit .rules file to stop prompting admins

### DIFF
--- a/accounts-service/com.endlessm.ParentalControls.rules
+++ b/accounts-service/com.endlessm.ParentalControls.rules
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2019 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+polkit.addRule(function(action, subject) {
+    /* Allow administrators to read parental controls (for any account) without
+     * needing an additional polkit authorisation dialogue. */
+    if ((action.id == "com.endlessm.ParentalControls.AppFilter.ReadOwn" ||
+         action.id == "com.endlessm.ParentalControls.AppFilter.ReadAny") &&
+        subject.active && subject.local &&
+        subject.isInGroup("sudo")) {
+            return polkit.Result.YES;
+    }
+
+    return polkit.Result.NOT_HANDLED;
+});

--- a/accounts-service/meson.build
+++ b/accounts-service/meson.build
@@ -11,3 +11,6 @@ install_data('com.endlessm.ParentalControls.AppFilter.xml',
 meson.add_install_script(meson_make_symlink,
   join_paths(dbusinterfacesdir, 'com.endlessm.ParentalControls.AppFilter.xml'),
   join_paths(accountsserviceinterfacesdir, 'com.endlessm.ParentalControls.AppFilter.xml'))
+
+install_data('com.endlessm.ParentalControls.rules',
+  install_dir: join_paths(get_option('datadir'), 'polkit-1', 'rules.d'))

--- a/debian/eos-parental-controls-data.install
+++ b/debian/eos-parental-controls-data.install
@@ -1,3 +1,4 @@
 usr/share/accountsservice/interfaces/com.endlessm.ParentalControls.AppFilter.xml
 usr/share/dbus-1/interfaces/com.endlessm.ParentalControls.AppFilter.xml
 usr/share/polkit-1/actions/com.endlessm.ParentalControls.policy
+usr/share/polkit-1/rules.d/com.endlessm.ParentalControls.rules


### PR DESCRIPTION
When logged in as an administrator, and editing other user accounts in
gnome-control-center, polkit keeps popping up authentication dialogues
to read or change other users’ parental controls data. That shouldn’t be
necessary since we’re an admin user, and it’s not a critical enough
action to need to prompt the admin to re-authenticate to make sure they
really want to make such changes.

Add a .rules file to squash the polkit prompts for reading other users’
parental controls. Keep the default policy of auth_admin_keep for
changing others’ parental controls, since that should be handled by the
‘Unlock’ button in g-c-c.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T23897