### PR TITLE
Depend on malcontent-data instead of eos-parental-controls-data (eos3.6)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Section: misc
 Architecture: any
 Multi-arch: same
 Depends:
- eos-parental-controls-data (= ${source:Version}),
+ malcontent-data,
  gir1.2-eos-parental-controls-0,
  gir1.2-glib-2.0,
  python3,
@@ -59,7 +59,7 @@ Package: libeos-parental-controls-0
 Section: misc
 Architecture: any
 Depends:
- eos-parental-controls-data (= ${source:Version}),
+ malcontent-data,
  ${misc:Depends},
  ${shlibs:Depends},
 Description: Parental Controls Library


### PR DESCRIPTION
> This is required as an initial transition from eos-parental-controls to
> malcontent. This change fixes a conflict when trying to install
> malcontent alongside eos-parental-controls.
> The malcontent-data and eos-parental-controls-data packages have the
> same content so no apps should be broken with this change.
>
> https://phabricator.endlessm.com/T26537

https://phabricator.endlessm.com/T27387